### PR TITLE
feat: add Ban/ChangeMaxPX/ChangeWinnerConfig

### DIFF
--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -22,4 +22,5 @@ mod tests {
     mod test_change_pixel_recovery;
     mod test_expand_area;
     mod test_ban_player;
+    mod test_change_max_px;
 }

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -23,4 +23,5 @@ mod tests {
     mod test_expand_area;
     mod test_ban_player;
     mod test_change_max_px;
+    mod test_change_winner_config;
 }

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -21,4 +21,5 @@ mod tests {
     mod test_change_game_duration;
     mod test_change_pixel_recovery;
     mod test_expand_area;
+    mod test_ban_player;
 }

--- a/contracts/src/models/game.cairo
+++ b/contracts/src/models/game.cairo
@@ -8,6 +8,10 @@ struct Game {
     start: u64,
     end: u64,
     proposal_idx: usize,
+    const_val: u32,
+    coeff_own_pixels: u32,
+    coeff_commits: u32,
+    winner_config: u32, // optimally, set by contract address.
     winner: ContractAddress,
 }
 

--- a/contracts/src/models/player.cairo
+++ b/contracts/src/models/player.cairo
@@ -6,6 +6,8 @@ struct Player {
     address: ContractAddress,
     // name: felt252,
     max_px: u32,
+    num_owns: u32,
+    num_commit: u32,
     current_px: u32,
     last_date: u64,
     is_banned: bool,

--- a/contracts/src/models/player.cairo
+++ b/contracts/src/models/player.cairo
@@ -8,4 +8,5 @@ struct Player {
     max_px: u32,
     current_px: u32,
     last_date: u64,
+    is_banned: bool,
 }

--- a/contracts/src/models/proposal.cairo
+++ b/contracts/src/models/proposal.cairo
@@ -2,7 +2,7 @@ use starknet::ContractAddress;
 
 #[derive(Copy, Drop, Serde, Introspect, PartialEq, Print)]
 struct Args {
-    toggle_allowed_app: ContractAddress,
+    address: ContractAddress,
     arg1: u64,
     arg2: u64,
 }
@@ -15,6 +15,7 @@ enum ProposalType {
     ChangeGameDuration,
     ChangePixelRecovery,
     ExpandArea,
+    BanPlayerAddress,
 }
 
 
@@ -61,7 +62,8 @@ impl ProposalTypeFelt252 of Into<ProposalType, felt252> {
             ProposalType::ToggleAllowedColor => 2,
             ProposalType::ChangeGameDuration => 3,
             ProposalType::ChangePixelRecovery => 4,            
-            ProposalType::ExpandArea => 5,       
+            ProposalType::ExpandArea => 5,
+            ProposalType::BanPlayerAddress => 6,
         }
     }
 }

--- a/contracts/src/models/proposal.cairo
+++ b/contracts/src/models/proposal.cairo
@@ -16,6 +16,7 @@ enum ProposalType {
     ChangePixelRecovery,
     ExpandArea,
     BanPlayerAddress,
+    ChangeMaxPXConfig,
 }
 
 
@@ -64,6 +65,7 @@ impl ProposalTypeFelt252 of Into<ProposalType, felt252> {
             ProposalType::ChangePixelRecovery => 4,            
             ProposalType::ExpandArea => 5,
             ProposalType::BanPlayerAddress => 6,
+            ProposalType::ChangeMaxPXConfig => 7,
         }
     }
 }

--- a/contracts/src/models/proposal.cairo
+++ b/contracts/src/models/proposal.cairo
@@ -17,6 +17,7 @@ enum ProposalType {
     ExpandArea,
     BanPlayerAddress,
     ChangeMaxPXConfig,
+    ChangeWinnerConfig,
 }
 
 
@@ -66,6 +67,7 @@ impl ProposalTypeFelt252 of Into<ProposalType, felt252> {
             ProposalType::ExpandArea => 5,
             ProposalType::BanPlayerAddress => 6,
             ProposalType::ChangeMaxPXConfig => 7,
+            ProposalType::ChangeWinnerConfig => 8,
         }
     }
 }

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -155,6 +155,10 @@ mod p_war_actions {
                 start,
                 end: start + GAME_DURATION,
                 proposal_idx: 0,
+                const_val: 10, // Default is 10.
+                coeff_own_pixels: 10,
+                coeff_commits: 10,
+                winner_config: 0,
                 winner: starknet::contract_address_const::<0x0>(),
             };
 
@@ -268,7 +272,7 @@ mod p_war_actions {
             let player_address = get_tx_info().unbox().account_contract_address;
 
             // recover px
-            recover_px(world, game_id.value);
+            recover_px(world, game_id.value, player_address);
 
             // if this is first time for the caller, let's set initial px.
             let mut player = get!(
@@ -290,11 +294,15 @@ mod p_war_actions {
                 (Player{
                     address: player.address,
                     max_px: player.max_px,
+                    num_owns: player.num_owns + 1,
+                    num_commit: player.num_commit + 1,
                     current_px: player.current_px - 1,
                     last_date: get_block_timestamp(),
                     is_banned: false,
                 }),
             );
+
+            // TODO: should reduce the num_owns of previous user.
         }
 
         fn update_pixel(world: IWorldDispatcher, pixel_update: PixelUpdate) {

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -335,7 +335,24 @@ mod p_war_actions {
 
             // TODO: get winner correctly
             // let winCondition = 0; // can we customize by contractaddress? or match&implement each?
-            let winner = starknet::contract_address_const::<0x0>(); // set for now.
+            let winner = match game.winner_config {
+                0 => {
+                    // set the person with the most pixels at the end as the winner.
+                    // TODO: get such a person. (We need to set  player.num_owns correctly.)
+                    starknet::contract_address_const::<0x0>()
+                },
+                1 => {
+                    // set the winner by the proposal directly.
+                    // already set the winner.
+                    game.winner
+                },
+                2 => {
+                    // winner is the person who has committied at the most.
+                    // TODO: get such a person.
+                    starknet::contract_address_const::<0x2>()
+                },
+                _ => {starknet::contract_address_const::<0x99>()},
+            };
 
             game.winner = winner;
 
@@ -343,6 +360,8 @@ mod p_war_actions {
                 world,
                 (game)
             );
+
+            // TODO: emit the winner!
         }
     }
 }

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -47,7 +47,7 @@ mod p_war_actions {
     use pixelaw::core::models::{ pixel::PixelUpdate, registry::App };
     use pixelaw::core::traits::IInteroperability;
     use p_war::systems::apps::{IAllowedApp, IAllowedAppDispatcher, IAllowedAppDispatcherTrait};
-    use p_war::systems::utils::recover_px;
+    use p_war::systems::utils::{ recover_px, update_max_px };
 
     #[event]
     #[derive(Drop, starknet::Event)]
@@ -156,8 +156,8 @@ mod p_war_actions {
                 end: start + GAME_DURATION,
                 proposal_idx: 0,
                 const_val: 10, // Default is 10.
-                coeff_own_pixels: 10,
-                coeff_commits: 10,
+                coeff_own_pixels: 0,
+                coeff_commits: 0,
                 winner_config: 0,
                 winner: starknet::contract_address_const::<0x0>(),
             };
@@ -303,6 +303,8 @@ mod p_war_actions {
             );
 
             // TODO: should reduce the num_owns of previous user.
+
+            update_max_px(world, game_id.value, player.address);
         }
 
         fn update_pixel(world: IWorldDispatcher, pixel_update: PixelUpdate) {

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -280,6 +280,9 @@ mod p_war_actions {
             // check the current px is not 0
             assert(player.current_px > 0, 'you cannot paint');
 
+            // check the player is banned or not
+            assert(player.is_banned == false, 'you are banned');
+
             app.set_pixel(default_params);
 
             set!(
@@ -289,6 +292,7 @@ mod p_war_actions {
                     max_px: player.max_px,
                     current_px: player.current_px - 1,
                     last_date: get_block_timestamp(),
+                    is_banned: false,
                 }),
             );
         }

--- a/contracts/src/systems/propose.cairo
+++ b/contracts/src/systems/propose.cairo
@@ -237,6 +237,30 @@ mod propose {
                     );
                     7
                 },
+                ProposalType::ChangeWinnerConfig => {
+                    // change config type by arg1
+                    // 0: set the person with the most pixels at the end as the winner.
+                    // 1: set the winner by the proposal directly.
+                    // 2: winner is the person who has committied at the most.
+
+                    let mut game = get!(
+                        world,
+                        (game_id),
+                        (Game)
+                    );
+                    game.winner_config = proposal.args.arg1.try_into().unwrap();
+
+                    if game.winner_config == 1 {
+                        // set winner
+                        game.winner = proposal.args.address;
+                    };
+
+                    set!(
+                        world,
+                        (game)
+                    );
+                    8
+                },
             };
 
         }

--- a/contracts/src/systems/propose.cairo
+++ b/contracts/src/systems/propose.cairo
@@ -202,6 +202,41 @@ mod propose {
                     );
                     6
                 },
+
+                ProposalType::ChangeMaxPXConfig => {
+                    // change config type by arg1
+                    let mut game = get!(
+                        world,
+                        (game_id),
+                        (Game)
+                    );
+                    match proposal.args.arg1 {
+
+                        // change constant value for max_px
+                        0 => {
+                            game.const_val = proposal.args.arg2.try_into().unwrap();
+                            0               
+                        },
+
+                        // change coefficient for number of own pixels for max_px
+                        1 => {
+                            game.coeff_own_pixels = proposal.args.arg2.try_into().unwrap();
+                            1
+                        },
+
+                        // change coefficient for the past commitments for max_px
+                        2 => {
+                            game.coeff_own_pixels = proposal.args.arg2.try_into().unwrap();
+                            1
+                        },
+                        _ => {7},
+                    };
+                    set!(
+                        world,
+                        (game)
+                    );
+                    7
+                },
             };
 
         }

--- a/contracts/src/systems/propose.cairo
+++ b/contracts/src/systems/propose.cairo
@@ -215,7 +215,7 @@ mod propose {
                         // change constant value for max_px
                         0 => {
                             game.const_val = proposal.args.arg2.try_into().unwrap();
-                            0               
+                            0
                         },
 
                         // change coefficient for number of own pixels for max_px
@@ -226,7 +226,7 @@ mod propose {
 
                         // change coefficient for the past commitments for max_px
                         2 => {
-                            game.coeff_own_pixels = proposal.args.arg2.try_into().unwrap();
+                            game.coeff_commits = proposal.args.arg2.try_into().unwrap();
                             1
                         },
                         _ => {7},

--- a/contracts/src/systems/propose.cairo
+++ b/contracts/src/systems/propose.cairo
@@ -1,4 +1,4 @@
-use starknet::{ContractAddress, get_caller_address, get_block_timestamp};
+use starknet::{ContractAddress, get_caller_address, get_block_timestamp, contract_address_const};
 use p_war::models::{game::{Game, Status}, proposal::{Args, ProposalType, Proposal}};
 
 const PROPOSAL_DURATION: u64 = 0; // should change it later.
@@ -19,6 +19,7 @@ mod propose {
         game::{Game, Status, GameTrait},
         proposal::{Args, ProposalType, Proposal, PixelRecoveryRate},
         board::{GameId, Board, Position},
+        player::{Player},
         allowed_app::AllowedApp,
         allowed_color::AllowedColor
     };
@@ -181,6 +182,25 @@ mod propose {
                         )
                     );
                     5
+                },
+
+                ProposalType::BanPlayerAddress => {
+                    let target_address: ContractAddress = proposal.args.address;
+                    let mut target_player = get!(
+                        world,
+                        (target_address),
+                        (Player)
+                    );
+
+                    target_player.is_banned = true;
+
+                    set!(
+                        world,
+                        (
+                            target_player
+                        )
+                    );
+                    6
                 },
             };
 

--- a/contracts/src/systems/utils.cairo
+++ b/contracts/src/systems/utils.cairo
@@ -24,6 +24,7 @@ fn recover_px(world: IWorldDispatcher, game_id: usize) {
         player.max_px = DEFAULT_PX;
         player.current_px = DEFAULT_PX;
         player.last_date = get_block_timestamp();
+        player.is_banned = false;
     } else {
         let recovery_rate = get!(
             world,

--- a/contracts/src/systems/utils.cairo
+++ b/contracts/src/systems/utils.cairo
@@ -11,42 +11,73 @@ use p_war::models::{
 
 const DEFAULT_PX: u32 = 10;
 
-fn recover_px(world: IWorldDispatcher, game_id: usize) {
-    let player_address = get_tx_info().unbox().account_contract_address;
+fn update_max_px(world: IWorldDispatcher, game_id: usize, player_address: ContractAddress){
     let mut player = get!(
         world,
         (player_address),
         (Player)
     );
 
-    // if this is first time for the caller, let's set initial px.
+    let game = get!(
+        world,
+        (game_id),
+        (Game)
+    );
+
+    let mut max_px = game.const_val + game.coeff_own_pixels * player.num_owns + game.coeff_commits * player.num_commit;
+
+    if max_px < 1 {
+        max_px = 1;
+    };
+
+    // if the player is new one:
     if player.max_px == 0 {
-        player.max_px = DEFAULT_PX;
-        player.current_px = DEFAULT_PX;
+        player.current_px = max_px;
         player.last_date = get_block_timestamp();
+        player.num_owns = 0;
+        player.num_commit = 0;
         player.is_banned = false;
+    };
+
+    player.max_px = max_px;
+
+    set!(
+        world,
+        (player)
+    );
+}
+
+fn recover_px(world: IWorldDispatcher, game_id: usize, player_address: ContractAddress) {
+    
+    update_max_px(world, game_id, player_address);
+
+    let mut player = get!(
+        world,
+        (player_address),
+        (Player)
+    );
+
+    let recovery_rate = get!(
+        world,
+        (game_id),
+        (PixelRecoveryRate)
+    );
+
+    let current_time = get_block_timestamp();
+    let time_diff = current_time - player.last_date;
+
+
+    let recover_pxs: u32 = ((time_diff) / recovery_rate.rate).try_into().unwrap();
+
+    if player.max_px >= (player.current_px + recover_pxs) {
+        player.current_px = player.current_px + recover_pxs;
     } else {
-        let recovery_rate = get!(
-            world,
-            (game_id),
-            (PixelRecoveryRate)
-        );
-
-        let current_time = get_block_timestamp();
-        let time_diff = current_time - player.last_date;
-
-        print!("\n ## RECOVERY_RATE: {} ##\n", recovery_rate.rate);
-
-        let recover_pxs: u32 = ((time_diff) / recovery_rate.rate).try_into().unwrap();
-
-        if player.max_px >= (player.current_px + recover_pxs) {
-            player.current_px = player.current_px + recover_pxs;
-        } else {
-            player.current_px = player.max_px;
-        }
+        player.current_px = player.max_px;
     }
 
-    print!("\n ### CURRENT PX: {} ###\n", player.current_px);
+    print!("\n## RECOVERY_RATE: {} ##\n", recovery_rate.rate);
+    print!("## RECOVER_PXS: {} ##\n", recover_pxs);
+    print!("## CURRENT PX: {} ##\n", player.current_px);
 
     set!(
         world,

--- a/contracts/src/systems/voting.cairo
+++ b/contracts/src/systems/voting.cairo
@@ -25,7 +25,7 @@ mod voting {
             let mut player_vote = get!(world, (player_address, game_id, index), (PlayerVote));
             assert(player_vote.px == 0, 'player already voted');
 
-            recover_px(world, game_id);
+            recover_px(world, game_id, player_address);
 
             let mut player = get!(
                 world,

--- a/contracts/src/systems/voting.cairo
+++ b/contracts/src/systems/voting.cairo
@@ -13,7 +13,7 @@ mod voting {
         player::{Player},
         proposal::{PlayerVote, Args, ProposalType, Proposal}
     };
-    use p_war::systems::utils::recover_px;
+    use p_war::systems::utils::{ recover_px, update_max_px };
 
     // one px vote per person
 
@@ -43,6 +43,7 @@ mod voting {
             }
 
             player.current_px -= use_px;
+            player.num_commit += use_px;
             set!(
                 world,
                 (player)
@@ -57,9 +58,9 @@ mod voting {
                     proposal,
                     player_vote
                 )
-            )
+            );
 
-
+            update_max_px(world, game_id, player_address);
         }
     }
 }

--- a/contracts/src/tests/test_change_game_duration.cairo
+++ b/contracts/src/tests/test_change_game_duration.cairo
@@ -103,7 +103,7 @@ mod tests {
         let change_duration: u64 = 100;
 
         let args = Args{
-            toggle_allowed_app: starknet::contract_address_const::<0x0>(),
+            address: starknet::contract_address_const::<0x0>(),
             arg1: change_duration,
             arg2: 0,
         }; 

--- a/contracts/src/tests/test_change_max_px.cairo
+++ b/contracts/src/tests/test_change_max_px.cairo
@@ -22,8 +22,9 @@ mod tests {
         systems::{
             actions::{p_war_actions, IActionsDispatcher, IActionsDispatcherTrait},
             propose::{propose, IProposeDispatcher, IProposeDispatcherTrait},
-            voting::{voting, IVotingDispatcher, IVotingDispatcherTrait}
-        }
+            voting::{voting, IVotingDispatcher, IVotingDispatcherTrait},
+            utils::update_max_px,
+        },
     };
 
     use pixelaw::core::{
@@ -129,15 +130,15 @@ mod tests {
         // should add cheat code to spend time
         propose_system.activate_proposal(id, index);
 
-        let player = get!(
+        let game = get!(
             world,
-            (caller),
-            (Player)
+            (id),
+            (Game)
         );
+        // print!("\n**** game state: {} ****", game.const_val);
+        assert(game.const_val == 20, 'const_val should be 20');
 
-        assert(player.max_px == 20, 'max_px should be 20');
-
-        // call place_pixel
+        // call place_pixel (to update player's max_px)
         let new_params = DefaultParameters{
             for_player: caller,
             for_system: caller,
@@ -149,6 +150,13 @@ mod tests {
         };
 
         actions_system.interact(new_params);
+
+        let player = get!(
+            world,
+            (caller),
+            (Player)
+        );
+        assert(player.max_px == 20, 'max_px should be 20');
 
         // change the max_px by num_owns
 
@@ -166,14 +174,29 @@ mod tests {
         );
 
 
-        // let index = propose_system.toggle_allowed_color(id, NEW_COLOR);
         let vote_px = 1;
         voting_system.vote(id, index, vote_px, true);
 
-        let proposal = get!(world, (id, index), (Proposal));
-
         // should add cheat code to spend time
         propose_system.activate_proposal(id, index);
+
+        // interact to update user's status
+        let another_params = DefaultParameters{
+            for_player: caller,
+            for_system: caller,
+            position: PixelawPosition {
+                x: 2,
+                y: 2
+            },
+            color: 0
+        };
+        actions_system.interact(another_params);
+
+        let game = get!(
+            world,
+            (id),
+            (Game)
+        );
 
         let player = get!(
             world,
@@ -181,8 +204,15 @@ mod tests {
             (Player)
         );
 
-        assert(player.max_px == 20 + 5 * 1, 'max_px should be 25');
+        print!("\n**** player max_px: {} ****\n", player.max_px);
+        print!("**** player num_commit: {} ****\n", player.num_commit);
+        print!("**** player num_owns: {} ****\n", player.num_owns);
+        print!("**** game const: {} ****\n", game.const_val);
+        print!("**** game coeff_commits: {} ****\n", game.coeff_commits);
+        print!("**** game coeff_own_pixels: {} ****\n", game.coeff_own_pixels);
+        let answer = game.const_val + game.coeff_commits * player.num_commit + game.coeff_own_pixels * player.num_owns;
+        print!("**** max_px should be: {} ****\n", answer);
+        
+        assert(player.max_px == 20 + 5 * player.num_commit, 'max_px should be 40');
     }
-
-
 }

--- a/contracts/src/tests/test_change_pixel_recovery.cairo
+++ b/contracts/src/tests/test_change_pixel_recovery.cairo
@@ -103,7 +103,7 @@ mod tests {
         let change_pixel_recovery: u64 = 20;
 
         let args = Args{
-            toggle_allowed_app: starknet::contract_address_const::<0x0>(),
+            address: starknet::contract_address_const::<0x0>(),
             arg1: change_pixel_recovery,
             arg2: 0,
         }; 

--- a/contracts/src/tests/test_change_winner_config.cairo
+++ b/contracts/src/tests/test_change_winner_config.cairo
@@ -1,0 +1,149 @@
+#[cfg(test)]
+mod tests {
+    use starknet::{
+        class_hash::Felt252TryIntoClassHash,
+        ContractAddress,
+        get_caller_address,
+    };
+    // import world dispatcher
+    use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
+    // import test utils
+    use dojo::test_utils::{spawn_test_world, deploy_contract};
+    // import test utils
+    use p_war::{
+        models::{
+            game::{Game, game},
+            board::{Board, GameId, Position, board, game_id},
+            proposal::{Args, ProposalType, Proposal},
+            player::{Player},
+            allowed_app::AllowedApp,
+            allowed_color::AllowedColor,
+        },
+        systems::{
+            actions::{p_war_actions, IActionsDispatcher, IActionsDispatcherTrait},
+            propose::{propose, IProposeDispatcher, IProposeDispatcherTrait},
+            voting::{voting, IVotingDispatcher, IVotingDispatcherTrait},
+            utils::update_max_px,
+        },
+    };
+
+    use pixelaw::core::{
+        models::{
+            permissions::permissions,
+            pixel::{pixel, Pixel, PixelUpdate},
+            queue::queue_item,
+            registry::{app, app_user, app_name, core_actions_address, instruction}
+        },
+        actions::{
+            actions as core_actions,
+            IActionsDispatcher as ICoreActionsDispatcher,
+            IActionsDispatcherTrait as ICoreActionsDispatcherTrait
+        },
+        utils::{DefaultParameters, Position as PixelawPosition}
+    };
+
+    const COLOR: u32 = 123456;
+
+    #[test]
+    #[available_gas(999_999_999)]
+    fn test_change_winner_config() {
+        // caller
+        let caller = starknet::contract_address_const::<0x0>();
+
+        // models
+        let mut models = array![
+            app::TEST_CLASS_HASH,
+            app_name::TEST_CLASS_HASH,
+            app_user::TEST_CLASS_HASH,
+            core_actions_address::TEST_CLASS_HASH,
+            core_actions_address::TEST_CLASS_HASH,
+            permissions::TEST_CLASS_HASH,
+            queue_item::TEST_CLASS_HASH,
+
+            game::TEST_CLASS_HASH,
+            board::TEST_CLASS_HASH,
+            game_id::TEST_CLASS_HASH
+        ];
+
+        // deploy world with models
+        let world = spawn_test_world(models);
+
+        let core_actions_contract_address = world
+            .deploy_contract('salt', core_actions::TEST_CLASS_HASH.try_into().unwrap());
+        let core_actions = ICoreActionsDispatcher { contract_address: core_actions_contract_address };
+
+        core_actions.init();
+
+        // deploy systems contract
+        let contract_address = world
+            .deploy_contract('salty', p_war_actions::TEST_CLASS_HASH.try_into().unwrap());
+        let actions_system = IActionsDispatcher { contract_address };
+
+        let propose_contract_address = world
+            .deploy_contract('salty1', propose::TEST_CLASS_HASH.try_into().unwrap());
+        let propose_system = IProposeDispatcher { contract_address: propose_contract_address };
+
+        let voting_contract_address = world
+            .deploy_contract('salty2', voting::TEST_CLASS_HASH.try_into().unwrap());
+        let voting_system = IVotingDispatcher { contract_address: voting_contract_address };
+
+        let default_params = DefaultParameters{
+            for_player: caller,
+            for_system: caller,
+            position: PixelawPosition {
+                x: 0,
+                y: 0
+            },
+            color: COLOR
+        };
+        
+        // create a game
+        actions_system.interact(default_params);
+
+        let id = actions_system.get_game_id(Position { x: default_params.position.x, y: default_params.position.y });
+        print!("id = {}", id);
+
+        // change config type by arg1
+        // 0: set the person with the most pixels at the end as the winner.
+        // 1: set the winner by the proposal directly.
+        // 2: winner is the person who has committied at the most.
+
+        let args = Args{
+            address: caller,
+            arg1: 1,
+            arg2: 0,
+        }; 
+
+        let index = propose_system.create_proposal(
+            game_id: id,
+            proposal_type: ProposalType::ChangeWinnerConfig,
+            args: args,
+        );
+
+
+        // let index = propose_system.toggle_allowed_color(id, NEW_COLOR);
+        let vote_px = 1;
+        voting_system.vote(id, index, vote_px, true);
+
+        let proposal = get!(world, (id, index), (Proposal));
+
+        print!("\n## PROPOSAL INFO ##\n");
+        
+        print!("Proposal end: {}\n", proposal.end);
+
+        // should add cheat code to spend time
+        propose_system.activate_proposal(id, index);
+        
+        // TODO: add cheat code to spend time
+        // actions_system.end_game(id);
+
+
+        let game = get!(
+            world,
+            (id),
+            (Game)
+        );
+        
+        // assert(game.winner == caller, 'winner should be the caller');
+    }
+}

--- a/contracts/src/tests/test_expand_area.cairo
+++ b/contracts/src/tests/test_expand_area.cairo
@@ -104,7 +104,7 @@ mod tests {
         let add_h: u64 = 4;
 
         let args = Args{
-            toggle_allowed_app: starknet::contract_address_const::<0x0>(),
+            address: starknet::contract_address_const::<0x0>(),
             arg1: add_w,
             arg2: add_h,
         }; 


### PR DESCRIPTION
Implemented and TODOs:
- [x] Ban an individual Address.
- [x] Change the maximum PX as follows:
    - [x] XX
    - [x] XX + YY * (number of pixels owned).
    - [x] XX + YY * (total pixels painted so far.)
- [x] Change the victory condition to: (implemented as a placeholder)
    - [x] The person with the most pixels at the end.
    - [x] Declare the person from <Address> as the winner.
    - [x] The person who has painted the most pixels.
- [ ] Optionally, players can propose an entirely new system. → toggled_app
    - [ ] Ideally, it would be entirely permissionless, but due to security and costs, the operator writes the contract in this version.
    
- [ ] If possible, we should implement the victory condition by setting a contract address. 
- [x] We have to set the owner of each pixel to get num_owns.

You can search "TODO" to find the rest to implement.