### PR TITLE
feat: add PWarPixel, paint_cost, author's incentives

### DIFF
--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -24,4 +24,5 @@ mod tests {
     mod test_ban_player;
     mod test_change_max_px;
     mod test_change_winner_config;
+    mod test_change_paint_cost;
 }

--- a/contracts/src/models/board.cairo
+++ b/contracts/src/models/board.cairo
@@ -1,3 +1,5 @@
+use starknet::{ContractAddress};
+
 #[derive(Copy, Drop, Serde, Introspect)]
 struct Position {
     x: u32,
@@ -12,6 +14,14 @@ struct Board {
     width: u32,
     height: u32,
 }
+
+#[derive(Model, Copy, Drop, Serde)]
+struct PWarPixel {
+    #[key]
+    position: Position,
+    owner: ContractAddress
+}
+
 
 #[derive(Model, Copy, Drop, Serde)]
 struct GameId {

--- a/contracts/src/models/game.cairo
+++ b/contracts/src/models/game.cairo
@@ -8,6 +8,7 @@ struct Game {
     start: u64,
     end: u64,
     proposal_idx: usize,
+    paint_cost: u32,
     const_val: u32,
     coeff_own_pixels: u32,
     coeff_commits: u32,

--- a/contracts/src/models/proposal.cairo
+++ b/contracts/src/models/proposal.cairo
@@ -18,6 +18,7 @@ enum ProposalType {
     BanPlayerAddress,
     ChangeMaxPXConfig,
     ChangeWinnerConfig,
+    ChangePaintCost,
 }
 
 
@@ -68,6 +69,7 @@ impl ProposalTypeFelt252 of Into<ProposalType, felt252> {
             ProposalType::BanPlayerAddress => 6,
             ProposalType::ChangeMaxPXConfig => 7,
             ProposalType::ChangeWinnerConfig => 8,
+            ProposalType::ChangePaintCost => 9,
         }
     }
 }

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -155,6 +155,7 @@ mod p_war_actions {
                 start,
                 end: start + GAME_DURATION,
                 proposal_idx: 0,
+                paint_cost: 1,
                 const_val: 10, // Default is 10.
                 coeff_own_pixels: 0,
                 coeff_commits: 0,
@@ -282,8 +283,16 @@ mod p_war_actions {
                 (Player)
             );
 
-            // check the current px is not 0
-            assert(player.current_px > 0, 'you cannot paint');
+            // get the game info
+            let game = get!(
+                world,
+                (game_id.value),
+                (Game)
+            );
+
+
+            // check the current px is eq or larger than cost_paint
+            assert(player.current_px >= game.paint_cost, 'you cannot paint');
 
             // check the player is banned or not
             assert(player.is_banned == false, 'you are banned');
@@ -296,8 +305,8 @@ mod p_war_actions {
                     address: player.address,
                     max_px: player.max_px,
                     num_owns: player.num_owns + 1,
-                    num_commit: player.num_commit + 1,
-                    current_px: player.current_px - 1,
+                    num_commit: player.num_commit + game.paint_cost,
+                    current_px: player.current_px - game.paint_cost,
                     last_date: get_block_timestamp(),
                     is_banned: false,
                 }),

--- a/contracts/src/systems/propose.cairo
+++ b/contracts/src/systems/propose.cairo
@@ -253,6 +253,8 @@ mod propose {
                     if game.winner_config == 1 {
                         // set winner
                         game.winner = proposal.args.address;
+
+                        // should we end the game instantly?? -> probably not.
                     };
 
                     set!(

--- a/contracts/src/systems/propose.cairo
+++ b/contracts/src/systems/propose.cairo
@@ -283,6 +283,19 @@ mod propose {
                 },
             };
 
+            // TODO: should we panish the author if the proposal is denied?
+            // add author's commitment points
+            let mut author = get!(
+                world,
+                (proposal.author),
+                (Player)
+            );
+
+            author.num_commit += 10; // get 10 commitments if the proposal is accepted
+            set!(
+                world,
+                (author)
+            );
         }
     }
 }

--- a/contracts/src/systems/propose.cairo
+++ b/contracts/src/systems/propose.cairo
@@ -263,6 +263,24 @@ mod propose {
                     );
                     8
                 },
+                ProposalType::ChangePaintCost => {
+                    // change the cost to paint 
+                    let mut game = get!(
+                        world,
+                        (game_id),
+                        (Game)
+                    );
+                    game.paint_cost = proposal.args.arg1.try_into().unwrap();
+
+                    set!(
+                        world,
+                        (game)
+                    );
+                    9
+                },
+                _ => {
+                    99
+                },
             };
 
         }

--- a/contracts/src/tests/test_change_paint_cost.cairo
+++ b/contracts/src/tests/test_change_paint_cost.cairo
@@ -1,0 +1,152 @@
+#[cfg(test)]
+mod tests {
+    use starknet::{
+        class_hash::Felt252TryIntoClassHash,
+        ContractAddress,
+        get_caller_address,
+    };
+    // import world dispatcher
+    use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
+    // import test utils
+    use dojo::test_utils::{spawn_test_world, deploy_contract};
+    // import test utils
+    use p_war::{
+        models::{
+            game::{Game, game},
+            board::{Board, GameId, Position, board, game_id},
+            proposal::{Args, ProposalType, Proposal},
+            player::{Player},
+            allowed_app::AllowedApp,
+            allowed_color::AllowedColor,
+        },
+        systems::{
+            actions::{p_war_actions, IActionsDispatcher, IActionsDispatcherTrait},
+            propose::{propose, IProposeDispatcher, IProposeDispatcherTrait},
+            voting::{voting, IVotingDispatcher, IVotingDispatcherTrait},
+            utils::update_max_px,
+        },
+    };
+
+    use pixelaw::core::{
+        models::{
+            permissions::permissions,
+            pixel::{pixel, Pixel, PixelUpdate},
+            queue::queue_item,
+            registry::{app, app_user, app_name, core_actions_address, instruction}
+        },
+        actions::{
+            actions as core_actions,
+            IActionsDispatcher as ICoreActionsDispatcher,
+            IActionsDispatcherTrait as ICoreActionsDispatcherTrait
+        },
+        utils::{DefaultParameters, Position as PixelawPosition}
+    };
+
+    const COLOR: u32 = 123456;
+
+    #[test]
+    #[available_gas(999_999_999)]
+    fn test_change_paint_cost() {
+        // caller
+        let caller = starknet::contract_address_const::<0x0>();
+
+        // models
+        let mut models = array![
+            app::TEST_CLASS_HASH,
+            app_name::TEST_CLASS_HASH,
+            app_user::TEST_CLASS_HASH,
+            core_actions_address::TEST_CLASS_HASH,
+            core_actions_address::TEST_CLASS_HASH,
+            permissions::TEST_CLASS_HASH,
+            queue_item::TEST_CLASS_HASH,
+
+            game::TEST_CLASS_HASH,
+            board::TEST_CLASS_HASH,
+            game_id::TEST_CLASS_HASH
+        ];
+
+        // deploy world with models
+        let world = spawn_test_world(models);
+
+        let core_actions_contract_address = world
+            .deploy_contract('salt', core_actions::TEST_CLASS_HASH.try_into().unwrap());
+        let core_actions = ICoreActionsDispatcher { contract_address: core_actions_contract_address };
+
+        core_actions.init();
+
+        // deploy systems contract
+        let contract_address = world
+            .deploy_contract('salty', p_war_actions::TEST_CLASS_HASH.try_into().unwrap());
+        let actions_system = IActionsDispatcher { contract_address };
+
+        let propose_contract_address = world
+            .deploy_contract('salty1', propose::TEST_CLASS_HASH.try_into().unwrap());
+        let propose_system = IProposeDispatcher { contract_address: propose_contract_address };
+
+        let voting_contract_address = world
+            .deploy_contract('salty2', voting::TEST_CLASS_HASH.try_into().unwrap());
+        let voting_system = IVotingDispatcher { contract_address: voting_contract_address };
+
+        let default_params = DefaultParameters{
+            for_player: caller,
+            for_system: caller,
+            position: PixelawPosition {
+                x: 0,
+                y: 0
+            },
+            color: COLOR
+        };
+        
+        // create a game
+        actions_system.interact(default_params);
+
+        let id = actions_system.get_game_id(Position { x: default_params.position.x, y: default_params.position.y });
+        print!("id = {}", id);
+
+        // change paint cost.
+        let args = Args{
+            address: starknet::contract_address_const::<0x0>(),
+            arg1: 3,
+            arg2: 0,
+        }; 
+
+        let index = propose_system.create_proposal(
+            game_id: id,
+            proposal_type: ProposalType::ChangePaintCost,
+            args: args,
+        );
+
+
+        let vote_px = 1;
+        voting_system.vote(id, index, vote_px, true);
+
+        let proposal = get!(world, (id, index), (Proposal));
+
+        print!("\n## PROPOSAL INFO ##\n");
+        print!("Proposal end: {}\n", proposal.end);
+
+        // should add cheat code to spend time
+        propose_system.activate_proposal(id, index);
+
+        // interact to update user's status
+        let another_params = DefaultParameters{
+            for_player: caller,
+            for_system: caller,
+            position: PixelawPosition {
+                x: 3,
+                y: 3
+            },
+            color: 0
+        };
+        actions_system.interact(another_params);
+
+        let player = get!(
+            world,
+            (caller),
+            (Player),
+        );
+        // print!("cu_px: {}", player.current_px);
+        assert(player.current_px == 10 - 1 - 3, 'current px should be 6');
+
+    }
+}

--- a/contracts/src/tests/test_change_winner_config.cairo
+++ b/contracts/src/tests/test_change_winner_config.cairo
@@ -138,11 +138,11 @@ mod tests {
         // actions_system.end_game(id);
 
 
-        let game = get!(
-            world,
-            (id),
-            (Game)
-        );
+        // let game = get!(
+        //     world,
+        //     (id),
+        //     (Game)
+        // );
         
         // assert(game.winner == caller, 'winner should be the caller');
     }


### PR DESCRIPTION
Implemented:
- `PWarPixel` to treat `num_owns`.
- update `change_max_px` based on `num_owns`.
- add `paint_cost` property to adjust inflation. (should we add inflation_percent instead of constant values?)
- add an author's commit points if the proposal gets approval.

TODO:
- get the winner correctly by using graphql. (this should be implemented on the client side??)
- Optionally, players can propose an entirely new system. → toggled_app
 - Ideally, it would be entirely permissionless, but due to security and costs, the operator writes the contract in this version.
- If possible, we should implement the victory condition by setting a contract address.
- more tests by using [foundry](https://foundry-rs.github.io/starknet-foundry/testing/using-cheatcodes.html)